### PR TITLE
add skel/test/mockup/*.sls to setup.py package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ config = {
             'skel/formula/map.jinja',
             'skel/formula/defaults.yml',
             'skel/formula/files/config.conf',
-            'skel/test/integration/default/serverspec/_spec.rb'
+            'skel/test/integration/default/serverspec/_spec.rb',
+            'skel/test/mockup/*.sls'
             ]
         },
     'scripts': [],


### PR DESCRIPTION
added skel/test/mockup/*.sls to package_data array in setup.py. kitchen convege|verify|test commands were failing without it.