### PR TITLE
Add Debian 9 to skeleton test-kitchen config

### DIFF
--- a/saltscaffold/skel/.kitchen-ci.yml
+++ b/saltscaffold/skel/.kitchen-ci.yml
@@ -23,6 +23,7 @@ provisioner:
 
 platforms:
   - name: debian_jessie
+  - name: debian_stretch
 
 suites:
   - name: default

--- a/saltscaffold/skel/.kitchen.yml
+++ b/saltscaffold/skel/.kitchen.yml
@@ -21,6 +21,7 @@ provisioner:
 
 platforms:
   - name: bento/debian-8.7
+  - name: bento/debian-9.0
 
 suites:
   - name: default


### PR DESCRIPTION
Now that Debian 9 is out, I tend to add it to my newer formulas if
only just to test against it. I think it'd be worthwhile to add it to
the skeleton formula.

Tested with both kitchen-vagrant (w/ virtualbox) and kitchen-linode on
my MacBook Pro.